### PR TITLE
Allow special characters to be parsed for links

### DIFF
--- a/app/Services/Service.php
+++ b/app/Services/Service.php
@@ -202,8 +202,22 @@ abstract class Service {
                     }
                     if (isset($count) && $count && isset($matches[1])) {
                         foreach ($matches[1] as $match) {
+                            // A bunch of special characters...
+                            $replacements = array(
+                                '&Agrave' => 'À', '&agrave;' => 'à', '&Aacute;' => 'Á', '&aacute;' => 'á', '&Acirc;' => 'Â', '&acirc;' => 'â', '&Atilde;' => 'Ã', '&atilde;' => 'ã',
+                                '&Auml;' => 'Ä', '&auml;' => 'ä', '&Aring;' => 'Å', '&aring;' => 'å', '&AElig;' => 'Æ', '&aelig;' => 'æ', '&Ccedil;' => 'Ç', '&ccedil;' => 'ç',
+                                '&ETH;' => 'Ð', '&eth;' => 'ð', '&Egrave;' => 'È', '&egrave;' => 'è', '&Eacute;' => 'É', '&eacute;' => 'é', '&Ecirc;' => 'Ê', '&ecirc;' => 'ê',
+                                '&Euml;' => 'Ë', '&euml;' => 'ë', '&Igrave;' => 'Ì', '&igrave;' => 'ì', '&Iacute;' => 'Í', '&iacute;' => 'í', '&Icirc;' => 'Î', '&icirc;' => 'î',
+                                '&Iuml;' => 'Ï', '&iuml;' => 'ï', '&Ntilde;' => 'Ñ', '&ntilde;' => 'ñ', '&Ograve;' => 'Ò', '&ograve;' => 'ò', '&Oacute;' => 'Ó', '&oacute;' => 'ó',
+                                '&Ocirc;' => 'Ô', '&ocirc;' => 'ô', '&Otilde;' => 'Õ', '&otilde;' => 'õ', '&Ouml;' => 'Ö', '&ouml;' => 'ö', '&Oslash;' => 'Ø', '&oslash;' => 'ø',
+                                '&OElig;' => 'Œ', '&oelig;' => 'œ', '&szlig;' => 'ß', '&THORN;' => 'Þ', '&thorn;' => 'þ', '&Ugrave;' => 'Ù', '&ugrave;' => 'ù', '&Uacute;' => 'Ú',
+                                '&uacute;' => 'ú', '&Ucirc;' => 'Û', '&ucirc;' => 'û', '&Uuml;' => 'Ü', '&uuml;' => 'ü', '&Yacute;' => 'Ý', '&yacute;' => 'ý', '&Yuml;' => 'Ÿ', '&yuml;' => 'ÿ'
+                            );
+                            // And replace any if found in the match
+                            $replaced = str_replace(array_keys($replacements), array_values($replacements), $match);
+
                             // Attempt to locate an associated page
-                            $page = Page::get()->where('displayTitle', $match)->first();
+                            $page = Page::get()->where('displayTitle', $replaced)->first();
 
                             // Make a version of the match suitable for regex replacement
                             $regexMatch = str_replace('(', '\(', $match);


### PR DESCRIPTION
## Description
Special and accented characters such as 'æ' and 'é' gets parsed by parse_wiki_links as their code versions, leading to the function being unable to match it with a page's title (which parses those characters normally) and therefore being unable to create a wiki link even though these characters are included in the regex's ranges.
This just adds a simple str_replace that will find and replace a code with their proper character (with the codes & characters stored in an array) and then stores the variable, which is then used instead to locate an associated page.

I've added a couple dozen special/accented characters to the array to cover a wide range of use cases!

## Related Issue
Discussed in discord!
Steps to reproduce the bug is to simply try making a [[link]] with any special/accented character in it; even if the page exists it will not link automatically, and peeking in the DB will show that the character was parsed into code.

## Motivation and Context
Useful for a wide variety of names, and even just some words like 'café'.

## How Has This Been Tested?
On local, tested with [[both]] [[styles of|wiki links]] with the characters æ, é, ß, and ñ.

## What Actions Do These Changes Require?
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project -OR- my changes only impact code for which style is automatically enforced (PHP).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added and/or updated tests to cover my changes (if applicable).
- [ ] All tests passed, including new tests (if applicable).
- [x] I license my contributions to this project under [the MIT License](../LICENSE-MIT.md), either directly or as a consequence of agreeing with the contributor license agreement printed below.

### Contributor License Agreement
I, Min, give itinerare permission to license my contributions on any terms they like.  I am giving them this license in order to make it possible for them to accept my contributions into their project.
***As far as the law allows, my contributions come as is, without any warranty or condition, and I will not be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***